### PR TITLE
Update aadAuthorizationEndpoint

### DIFF
--- a/Demos/DailyReporterPro/DailyReporterPro/Models/PbiEmbeddedManager.cs
+++ b/Demos/DailyReporterPro/DailyReporterPro/Models/PbiEmbeddedManager.cs
@@ -28,7 +28,7 @@ namespace DailyReporterPro.Models {
 
   public class PbiEmbeddedManager {
 
-    static string aadAuthorizationEndpoint = "https://login.windows.net/common/oauth2/authorize";
+    static string aadAuthorizationEndpoint = "https://login.microsoftonline.com/common";
     static string resourceUriPowerBi = "https://analysis.windows.net/powerbi/api";
     static string urlPowerBiRestApiRoot = "https://api.powerbi.com/";
 

--- a/Demos/EmbeddedLab/EmbeddedLab/Models/PbiEmbeddedManager.cs
+++ b/Demos/EmbeddedLab/EmbeddedLab/Models/PbiEmbeddedManager.cs
@@ -13,7 +13,7 @@ namespace EmbeddedLab.Models {
 
     #region "private implementation details"
 
-    private static string aadAuthorizationEndpoint = "https://login.windows.net/common/oauth2/authorize";
+    private static string aadAuthorizationEndpoint = "https://login.microsoftonline.com/common";
     private static string resourceUriPowerBi = "https://analysis.windows.net/powerbi/api";
     private static string urlPowerBiRestApiRoot = "https://api.powerbi.com/";
 


### PR DESCRIPTION
ADAL 4.x does not accept https://login.windows.net/common/oauth2/authorize as a valid auth endpoint (see https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1346). This PR updates DailyReporterPro and EmbeddedLab to use https://login.microsoftonline.com/common instead.

Note: this has not been tested with ADAL < 4.3, which may not work with this endpoint.